### PR TITLE
Add permissions to validation workflow

### DIFF
--- a/.github/workflows/azure-dev-validation.yaml
+++ b/.github/workflows/azure-dev-validation.yaml
@@ -8,11 +8,14 @@ on:
     branches: [ main ]
     paths:
       - "infra/**"
+  workflow_dispatch:
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +33,7 @@ jobs:
           tools: templateanalyzer
 
       - name: Upload alerts to Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: github.repository == 'Azure-Samples/chat-rag-openai-csharp-prompty'
         with:
           sarif_file: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
The validation workflow is failing because it's missing some permissions. This fixes that.

I also updated the task to the latest version and added workflow dispatch so it can be run manually. 